### PR TITLE
Skip blank build tags

### DIFF
--- a/genesis.go
+++ b/genesis.go
@@ -124,7 +124,11 @@ func (enc *Encoder) ensureHeaderWritten() error {
 
 	// Write build tags.
 	for _, tag := range enc.Tags {
-		fmt.Fprintf(&buf, "// +build %s\n\n", strings.TrimSpace(tag))
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+		fmt.Fprintf(&buf, "// +build %s\n\n", tag)
 		fmt.Fprintln(&buf, "")
 	}
 


### PR DESCRIPTION
Hi. Genesis is a simple and great package, a great candidate to replace go-bindata. This PR addresses the build tag issue.

When no `--tags` flag is provided, strings.Split function creates a slice with one blank string making the generated file contains only `// +build ` line without any tags in it, preventing build completely. This PR change handles other cases where any tags string is blank, which is possible when `,` is the first or last character in `--tags` flag argument, and also if `,` repeated without any other characters in between. 